### PR TITLE
fix: trim is not a function of number

### DIFF
--- a/lib/xml_generator.js
+++ b/lib/xml_generator.js
@@ -16,7 +16,7 @@ module.exports = function(locals){
   var template = searchTmpl;
   var searchfield = searchConfig.field.trim();
   var searchformat = searchConfig.format.trim();
-  var searchlimit = searchConfig.limit.trim();
+  var searchlimit = searchConfig.limit;
   var posts, pages, raw;
 
   if(searchfield != ''){


### PR DESCRIPTION
When `search.limit` is a number, `trim` cannot be applied to it.

For example, when we config as follow:

```yaml
search:
  path: search.xml
  field: post
  format: html
  limit: 10000
```

The following error will appear when running `hexo generate`:

```
TypeError: searchConfig.limit.trim is not a function
    at Hexo.module.exports (D:\develop\hexo\bug-demo\node_modules\hexo-generator-searchdb\lib\xml_generator.js:19:40)
    at Hexo.tryCatcher (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\util.js:16:23)
    at Hexo.<anonymous> (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\method.js:15:34)
    at D:\develop\hexo\bug-demo\node_modules\hexo\lib\hexo\index.js:338:24
    at tryCatcher (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\util.js:16:23)
    at MappingPromiseArray._promiseFulfilled (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\map.js:61:38)
    at MappingPromiseArray.PromiseArray._iterate (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\promise_array.js:114:31)
    at MappingPromiseArray.init (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\promise_array.js:78:10)
    at MappingPromiseArray._asyncInit (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\map.js:30:10)
    at Async._drainQueue (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\async.js:138:12)
    at Async._drainQueues (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\async.js:143:10)
    at Immediate.Async.drainQueues (D:\develop\hexo\bug-demo\node_modules\bluebird\js\release\async.js:17:14)
    at runCallback (timers.js:666:20)
    at tryOnImmediate (timers.js:639:5)
    at processImmediate [as _immediateCallback] (timers.js:611:5)
```
